### PR TITLE
Use unofficial FPSci v25.01.01

### DIFF
--- a/configs/startupconfig.Any
+++ b/configs/startupconfig.Any
@@ -1,5 +1,6 @@
 { 
     audioEnable = true;         // Set to true for release
+    experimentListEnable = true;  // Set to true for release
     developerMode = false;       // Set to false for release
     fullscreen = true;         // Set to true for release
     waypointEditorMode = false; // Set to false for release

--- a/setup.bat
+++ b/setup.bat
@@ -1,9 +1,11 @@
-set FPSCI_VERSION=v23.04.01
+set FPSCI_VERSION=v25.01.01
 set HIDESEEK_FOLDER_ID=1hryO2ewrrQhKmApf-CizbCejUztCxEv9
 
 @REM Get FPSci build
+@REM official releases should use this path https://github.com/NVlabs/FPSci/releases/download/%FPSCI_VERSION%/FPSci.%FPSCI_VERSION%.zip
+@REM unofficial releases should use this path https://github.com/jspjut/FPSci/releases/download/%FPSCI_VERSION%/FPSci.%FPSCI_VERSION%.zip
 echo Downloading FPSci
-curl -LO https://github.com/NVlabs/FPSci/releases/download/%FPSCI_VERSION%/FPSci.%FPSCI_VERSION%.zip
+curl -LO https://github.com/jspjut/FPSci/releases/download/%FPSCI_VERSION%/FPSci.%FPSCI_VERSION%.zip
 echo Extracting FPSci
 mkdir FPSci
 tar -xf FPSci.%FPSCI_VERSION%.zip -C FPSci\


### PR DESCRIPTION
This PR switches to using the unofficial v25.01.01 that allows the experiment dropdown list with developer mode off.